### PR TITLE
fix: update SixLabors.ImageSharp  to 3.1.4 to mitigate CVE-2024-27929 vulnerability

### DIFF
--- a/UnityCNLive2DExtractor/UnityCNLive2DExtractor.csproj
+++ b/UnityCNLive2DExtractor/UnityCNLive2DExtractor.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Kyaru.Texture2DDecoder" Version="0.17.0" />
     <PackageReference Include="Kyaru.Texture2DDecoder.Windows" Version="0.1.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="3.0.1" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="3.1.4" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />


### PR DESCRIPTION
This PR updates the SixLabors.ImageSharp package to version 3.1.4 to mitigate a CVE-2024-27929 vulnerability found in previous versions. 

Why not use 3.1.3? 

Because version 3.1.3 contained two vulnerabilities, CVE-2024-32035 and CVE-2024-32036, which were fixed in version 3.1.4.

I have tested this change in my environment and everything seems to work as expected.